### PR TITLE
Fixed incorrect carbon intensity calculation

### DIFF
--- a/database/ad-hoc/20230605-carbon-intensity-constants.sql
+++ b/database/ad-hoc/20230605-carbon-intensity-constants.sql
@@ -3,11 +3,11 @@
 
 INSERT INTO CarbonIntensityByFuelType(FuelType, CarbonIntensity, "Group")
 VALUES
-    ('battery', 251, 'Renewable'),   -- only when discharging (positive amount of power)
-    ('biomass', 230, 'Renewable'),
+    ('battery', 251, 'NonRenewable'),   -- only when discharging (positive amount of power)
+    ('biomass', 230, 'NonRenewable'),
     ('coal', 820, 'NonRenewable'),
-    ('gas', 490, 'Renewable'),
-    ('geothermal', 38, , 'Renewable'),
+    ('gas', 490, 'NonRenewable'),
+    ('geothermal', 38, 'Renewable'),
     ('hydro', 24, 'Renewable'),
     ('import', 460, 'NonRenewable'),    -- average across the US for now.
     ('nuclear', 12, 'Renewable'),
@@ -15,7 +15,7 @@ VALUES
     ('other', 700, 'NonRenewable'),
     ('solar', 45, 'Renewable'),
     ('unknown', 700, 'NonRenewable'),
-    ('unknown-renewables', 230 , 'Renewable'),
+    ('unknown-renewables', 230 , 'NonRenewable'),
     ('wind', 11, 'Renewable'),
     ('wind/solar', 28, 'Renewable')
 

--- a/database/ad-hoc/20230605-carbon-intensity-constants.sql
+++ b/database/ad-hoc/20230605-carbon-intensity-constants.sql
@@ -1,0 +1,21 @@
+-- This script sets the carbon intensity constants.
+-- Source: electricityMap
+
+INSERT INTO CarbonIntensityByFuelType(FuelType, CarbonIntensity, "Group")
+VALUES
+    ('battery', 251, 'Renewable'),   -- only when discharging (positive amount of power)
+    ('biomass', 230, 'Renewable'),
+    ('coal', 820, 'NonRenewable'),
+    ('gas', 490, 'Renewable'),
+    ('geothermal', 38, , 'Renewable'),
+    ('hydro', 24, 'Renewable'),
+    ('import', 460, 'NonRenewable'),    -- average across the US for now.
+    ('nuclear', 12, 'Renewable'),
+    ('oil', 650, 'NonRenewable'),
+    ('other', 700, 'NonRenewable'),
+    ('solar', 45, 'Renewable'),
+    ('unknown', 700, 'NonRenewable'),
+    ('unknown-renewables', 230 , 'Renewable'),
+    ('wind', 11, 'Renewable'),
+    ('wind/solar', 28, 'Renewable')
+

--- a/database/ad-hoc/20230605-negative-values-check.sql
+++ b/database/ad-hoc/20230605-negative-values-check.sql
@@ -1,0 +1,19 @@
+-- This script checks for irregular negative values in certain fuel types
+
+select distinct on (category) datetime, region, category
+    from energymixture
+    where power_mw < -10;
+
+
+select * from energymixture
+    where region = 'US-MISO' and category = 'unknown' and power_mw < -10;
+
+
+-- Results:
+-- US-CAISO,battery		normal (charging)
+-- US-CAISO,biomass		one off (1)
+-- US-CAISO,geothermal		one off (1)
+-- US-CAISO,hydro			normal (charging)
+-- US-CAISO,import			normal (export)
+-- US-MISO,solar			one off (3)
+-- US-MISO,unknown			quite a lot from 2022/

--- a/database/views/view.carbon-intensity-weighted.sql
+++ b/database/views/view.carbon-intensity-weighted.sql
@@ -2,11 +2,11 @@ CREATE VIEW CarbonIntensityByRenewable
 AS
     SELECT DateTime,
             Region,
-            COALESCE(SUM(CASE WHEN ci.group = 'Renewable' THEN Power_MW * CarbonIntensity ELSE 0 END)
+            COALESCE(SUM(CASE WHEN ci.group = 'Renewable' THEN Power_MW * (CASE WHEN carbonintensity is NULL THEN 700 ELSE greatest(0, carbonintensity) END) ELSE 0 END)
                         / NULLIF(SUM(CASE WHEN ci.group = 'Renewable' THEN Power_MW ELSE 0 END), 0),
                 0)
                 AS Renewable_CarbonIntensity,
-            COALESCE(SUM(CASE WHEN ci.group != 'Renewable' THEN Power_MW * CarbonIntensity ELSE 0 END)
+            COALESCE(SUM(CASE WHEN ci.group != 'Renewable' THEN Power_MW * (CASE WHEN carbonintensity is NULL THEN 700 ELSE greatest(0, carbonintensity) END) ELSE 0 END)
                         / NULLIF(SUM(CASE WHEN ci.group != 'Renewable' THEN Power_MW ELSE 0 END), 0),
                 0)
                 AS NonRenewable_CarbonIntensity,

--- a/database/views/view.carbon-intensity.sql
+++ b/database/views/view.carbon-intensity.sql
@@ -1,7 +1,9 @@
 CREATE VIEW CarbonIntensity
 AS
-    SELECT DateTime, Region, SUM(Power_MW * CarbonIntensity) / SUM(Power_MW) AS CarbonIntensity
-        FROM EnergyMixture INNER JOIN CarbonIntensityByFuelType
+    SELECT DateTime,
+            Region,
+            SUM(Power_MW * CASE WHEN carbonintensity is NULL THEN 700 ELSE greatest(0, carbonintensity) END) / SUM(Power_MW) AS CarbonIntensity
+        FROM EnergyMixture LEFT OUTER JOIN CarbonIntensityByFuelType
             ON EnergyMixture.Category = CarbonIntensityByFuelType.FuelType
         GROUP BY DateTime, Region
         ORDER BY DateTime DESC, Region;


### PR DESCRIPTION
Existing constant lookup table of per-fuel-type carbon intensity has been mysteriously changed.

I created a new updated table and assigns a default value of 700 for not-matched fuel types instead of ignoring them (in the case of INNER JOIN).