### PR TITLE
Added linear time algorithm to optimize total carbon emissions

### DIFF
--- a/api/helpers/carbon_intensity.py
+++ b/api/helpers/carbon_intensity.py
@@ -488,8 +488,8 @@ def calculate_total_carbon_emissions_linear(start: datetime, runtime: timedelta,
                 step_t1 = T4 - T0   # Large enough so it's bigger than step_t2, so this is not considered
             step_t2 = next((op for op in OPs[2] if op > t2), T2_MAX) - t2
             if integrals[3]:
-                # Moving t2 might disable the current optimal t3, and the minimal distance is from current optimal_t3 to the next OP.
-                step_t3 = next((op for op in OPs[3] if op > optimal_t3), T3_MAX) - optimal_t3
+                # Moving t2 might disable the current optimal t3, and the minimal distance is from current t3_min to the next OP.
+                step_t3 = next((op for op in OPs[3] if op > t3_min), T3_MAX) - t3_min
             else:
                 step_t3 = T4 - T0   # Large enough so it's bigger than step_t2, so this is not considered
             t2 += max(min(step_t1, step_t2, step_t3), 1) # Make sure step is at least 1

--- a/api/helpers/carbon_intensity.py
+++ b/api/helpers/carbon_intensity.py
@@ -320,12 +320,12 @@ def calculate_total_carbon_emissions_linear(start: datetime, runtime: timedelta,
 
     # Linear algorithm described in appendix A of the paper.
 
-    def calculate_integral_optimized(D, T_min, T_max, steps):
+    def calculate_integral_optimized(D, T_min, T_max, steps) -> dict[int, float]:
         """Calculate the integral of a step function with a given window [T_min, T_max] and step size D."""
         if len(steps) == 0:
             return {}
 
-        integral = {}
+        integral: dict[int, float] = {}
         last_step_time = T_min
         last_step_value = 0
 
@@ -398,7 +398,10 @@ def calculate_total_carbon_emissions_linear(start: datetime, runtime: timedelta,
         return OP
 
     # Main function to optimize total carbon
-    def optimize_total_carbon(f1_steps, f2_steps, f3_steps, T0, T4, D1, D2, D3):
+    def optimize_total_carbon(f1_steps: list[tuple[int, float]],
+                              f2_steps: list[tuple[int, float]],
+                              f3_steps: list[tuple[int, float]],
+                              T0: int, T4: int, D1: int, D2: int, D3: int):
         integrals = {}
         OPs = {}
         assert T0 == 0, "T0 should be set to 0."

--- a/api/helpers/carbon_intensity.py
+++ b/api/helpers/carbon_intensity.py
@@ -428,8 +428,8 @@ def calculate_total_carbon_emissions_linear(start: datetime, runtime: timedelta,
             if integrals[1]:
                 t1_max = t2 - D1
                 op1 = max([op for op in OPs[1] if op <= t1_max], default=t1_max)
-                optimal_t1 = min((integrals[1][op1 - T0], op1), (integrals[1][t1_max - T0], t1_max), key=lambda x: x[0])[1]
-                min_integral_1 = integrals[1][optimal_t1 - T0]
+                optimal_t1 = min((integrals[1][op1], op1), (integrals[1][t1_max], t1_max), key=lambda x: x[0])[1]
+                min_integral_1 = integrals[1][optimal_t1]
             else:
                 optimal_t1 = 0
                 min_integral_1 = 0
@@ -438,18 +438,18 @@ def calculate_total_carbon_emissions_linear(start: datetime, runtime: timedelta,
             if integrals[3]:
                 t3_min = t2 + D2
                 op3 = min([op for op in OPs[3] if op >= t3_min], default=t3_min)
-                optimal_t3 = min((integrals[3][op3 - T0], op3), (integrals[3][t3_min - T0], t3_min), key=lambda x: x[0])[1]
-                min_integral_3 = integrals[3][optimal_t3 - T0]
+                optimal_t3 = min((integrals[3][op3], op3), (integrals[3][t3_min], t3_min), key=lambda x: x[0])[1]
+                min_integral_3 = integrals[3][optimal_t3]
             else:
                 optimal_t3 = t2 + D2
                 min_integral_3 = 0
 
             # Compare total integral
-            integral_total = min_integral_1 + integrals[2][t2 - T0] + min_integral_3
+            integral_total = min_integral_1 + integrals[2][t2] + min_integral_3
             if not math.isclose(integral_total, min_integral_total) and integral_total < min_integral_total:
                 min_integral_total = integral_total
                 T_optimal = [optimal_t1, t2, optimal_t3]
-                min_integrals = [min_integral_1, integrals[2][t2 - T0], min_integral_3]
+                min_integrals = [min_integral_1, integrals[2][t2], min_integral_3]
 
         perf_elapsed = time.time() - perf_start_time
         current_app.logger.debug('optimize_total_carbon() took %.3f seconds' % perf_elapsed)

--- a/api/helpers/carbon_intensity.py
+++ b/api/helpers/carbon_intensity.py
@@ -519,6 +519,15 @@ def calculate_total_carbon_emissions_linear(start: datetime, runtime: timedelta,
             steps = [(int((t - T0_datetime).total_seconds()), value) for t, value in f_series.items()]
             return steps
 
+        # Validate we have enough data points to cover the entire time range [T0, T4]
+        for carbon_rates in [carbon_rates_1, carbon_rates_2, carbon_rates_3]:
+            if carbon_rates.empty:
+                continue
+            if carbon_rates.index[0] > T0:
+                raise ValueError("Not enough data points to cover the entire time range.")
+            if carbon_rates.index[-1] < T4:
+                raise ValueError("Not enough data points to cover the entire time range.")
+
         # Convert datetime and timedelta to seconds
         T0s = datetime_to_seconds(T0, T0)
         T4s = datetime_to_seconds(T0, T4)

--- a/api/helpers/carbon_intensity.py
+++ b/api/helpers/carbon_intensity.py
@@ -428,6 +428,8 @@ def calculate_total_carbon_emissions_linear(start: datetime, runtime: timedelta,
             if integrals[1]:
                 t1_max = t2 - D1
                 op1 = max([op for op in OPs[1] if op <= t1_max], default=t1_max)
+                # Order matters in argmin call below, as we want to pick the earlier time in case of equal values.
+                # In this case, op1 <= t1_max
                 optimal_t1 = min((integrals[1][op1], op1), (integrals[1][t1_max], t1_max), key=lambda x: x[0])[1]
                 min_integral_1 = integrals[1][optimal_t1]
             else:
@@ -438,7 +440,9 @@ def calculate_total_carbon_emissions_linear(start: datetime, runtime: timedelta,
             if integrals[3]:
                 t3_min = t2 + D2
                 op3 = min([op for op in OPs[3] if op >= t3_min], default=t3_min)
-                optimal_t3 = min((integrals[3][op3], op3), (integrals[3][t3_min], t3_min), key=lambda x: x[0])[1]
+                # Order matters in argmin call below, as we want to pick the earlier time in case of equal values.
+                # In this case, t3_min <= op3
+                optimal_t3 = min((integrals[3][t3_min], t3_min), (integrals[3][op3], op3), key=lambda x: x[0])[1]
                 min_integral_3 = integrals[3][optimal_t3]
             else:
                 optimal_t3 = t2 + D2

--- a/api/models/workload.py
+++ b/api/models/workload.py
@@ -146,7 +146,7 @@ class Workload:
     watts_per_core: float = field(default=DEFAULT_CPU_POWER_PER_CORE)
     core_count: float = field(default=1.)
 
-    use_new_optimization: bool = field(default=False)
+    use_new_optimization: bool = field(default=True)
     carbon_accounting_mode: CarbonAccountingMode = field_enum(CarbonAccountingMode, CarbonAccountingMode.ComputeOnly)
 
     @validates_schema

--- a/api/models/workload.py
+++ b/api/models/workload.py
@@ -146,6 +146,7 @@ class Workload:
     watts_per_core: float = field(default=DEFAULT_CPU_POWER_PER_CORE)
     core_count: float = field(default=1.)
 
+    use_new_optimization: bool = field(default=False)
     carbon_accounting_mode: CarbonAccountingMode = field_enum(CarbonAccountingMode, CarbonAccountingMode.ComputeOnly)
 
     @validates_schema

--- a/api/routes/carbon_aware_scheduler.py
+++ b/api/routes/carbon_aware_scheduler.py
@@ -169,6 +169,7 @@ def get_carbon_emission_rates_as_pd_series(iso: ISOName, start: datetime, end: d
         ds_freq = to_offset(np.diff(ds.index).min())
         # pd.infer_freq() only works with perfectly regular frequency
         # ds_freq = to_offset(pd.infer_freq(ds.index))
+    ds.ffill(inplace=True)
     end_time_of_series = ds.index.max() + ds_freq
     ds[end_time_of_series.to_pydatetime()] = 0.
 

--- a/api/routes/carbon_aware_scheduler.py
+++ b/api/routes/carbon_aware_scheduler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from datetime import timedelta, timezone
 import json
+from math import ceil
 from multiprocessing import Pool
 import traceback
 from typing import Any
@@ -142,7 +143,9 @@ def get_transfer_rate(route: list[CloudRegion], start: datetime, end: datetime, 
 
 def get_transfer_time(data_size_gb: float, transfer_rate: Rate) -> timedelta:
     data_size = Size(data_size_gb, SizeUnit.GB)
-    return data_size / transfer_rate
+    transfer_time: timedelta = (data_size / transfer_rate)
+    # Round to whole seconds for a later algorithm.
+    return timedelta(seconds=ceil(transfer_time.total_seconds()))
 
 def get_per_hop_transfer_power_in_watts(route: CloudRegion, transfer_rate: Rate) -> float:
     # NOTE: only consider routers for now.

--- a/api/routes/carbon_aware_scheduler.py
+++ b/api/routes/carbon_aware_scheduler.py
@@ -157,10 +157,11 @@ def get_carbon_emission_rates_as_pd_series(iso: ISOName, start: datetime, end: d
     l_carbon_intensity = get_preloaded_carbon_data(iso, start, end)
     df = pd.DataFrame(l_carbon_intensity)
     df.set_index('timestamp', inplace=True)
+    df.sort_index(inplace=True)
 
-    # Only consider hourly data
-    df = df.loc[df.index.minute == 0]
-    ds = df['carbon_intensity'].sort_index()
+    # Only consider hourly data, using average carbon intensity.
+    df = df.resample('H').mean()
+    ds = df['carbon_intensity']
     # Conversion: gCO2/kWh * W * 1/(1000*3600) kh/s = gCO2/s
     ds = ds * power_in_watts / (1000 * 3600)
     ds.sort_index(inplace=True)

--- a/api/routes/carbon_aware_scheduler.py
+++ b/api/routes/carbon_aware_scheduler.py
@@ -156,6 +156,8 @@ def get_per_hop_transfer_power_in_watts(route: CloudRegion, transfer_rate: Rate)
 def get_carbon_emission_rates_as_pd_series(iso: ISOName, start: datetime, end: datetime, power_in_watts: float) -> pd.Series:
     l_carbon_intensity = get_preloaded_carbon_data(iso, start, end)
     df = pd.DataFrame(l_carbon_intensity)
+    # Force conversion using UTC is needed to handle multiple timezones
+    df['timestamp'] = pd.to_datetime(df['timestamp'], utc=True)
     df.set_index('timestamp', inplace=True)
     df.sort_index(inplace=True)
 

--- a/api/routes/carbon_aware_scheduler.py
+++ b/api/routes/carbon_aware_scheduler.py
@@ -14,7 +14,7 @@ from pandas.tseries.frequencies import to_offset
 from webargs.flaskparser import use_args
 from api.helpers.balancing_authority import get_iso_from_gps
 
-from api.helpers.carbon_intensity import calculate_total_carbon_emissions, get_carbon_intensity_list
+from api.helpers.carbon_intensity import get_carbon_intensity_list, calculate_total_carbon_emissions_linear as calculate_total_carbon_emissions
 from api.models.cloud_location import CloudLocationManager, CloudRegion, get_route_between_cloud_regions
 from api.models.common import CarbonDataSource, Coordinate, ISOName, RouteInISO, get_iso_format_for_carbon_source, identify_iso_format
 from api.models.optimization_engine import OptimizationEngine, OptimizationFactor

--- a/api/routes/carbon_aware_scheduler.py
+++ b/api/routes/carbon_aware_scheduler.py
@@ -398,7 +398,7 @@ class CarbonAwareScheduler(Resource):
             result = pool.map(task_process_candidate, candidate_regions)
         for (region_name, iso, scores, d_misc, ex, stack_trace) in result:
             d_region_isos[region_name] = iso
-            if not ex:
+            if not (ex or stack_trace):
                 scores[OptimizationFactor.EnergyUsage + '-unit'] = 'kWh'
                 scores[OptimizationFactor.CarbonEmission + '-unit'] = 'gCO2'
                 d_region_scores[region_name] = scores

--- a/api/routes/carbon_aware_scheduler.py
+++ b/api/routes/carbon_aware_scheduler.py
@@ -176,6 +176,9 @@ def get_carbon_emission_rates_as_pd_series(iso: ISOName, start: datetime, end: d
     end_time_of_series = ds.index.max() + ds_freq
     ds[end_time_of_series.to_pydatetime()] = 0.
 
+    assert ds.index.min() <= start and end <= ds.index.max(), \
+        f'Carbon data not available for iso {iso} for the entire time range [{start}, {end}]'
+
     return ds
 
 def get_compute_carbon_emission_rates(iso: ISOName, start: datetime, end: datetime, host_power_in_watts: float) -> pd.Series:

--- a/api/routes/carbon_aware_scheduler.py
+++ b/api/routes/carbon_aware_scheduler.py
@@ -15,7 +15,7 @@ from pandas.tseries.frequencies import to_offset
 from webargs.flaskparser import use_args
 from api.helpers.balancing_authority import get_iso_from_gps
 
-from api.helpers.carbon_intensity import get_carbon_intensity_list, calculate_total_carbon_emissions_linear as calculate_total_carbon_emissions
+from api.helpers.carbon_intensity import get_carbon_intensity_list, calculate_total_carbon_emissions_linear, calculate_total_carbon_emissions_naive
 from api.models.cloud_location import CloudLocationManager, CloudRegion, get_route_between_cloud_regions
 from api.models.common import CarbonDataSource, Coordinate, ISOName, RouteInISO, get_iso_format_for_carbon_source, identify_iso_format
 from api.models.optimization_engine import OptimizationEngine, OptimizationFactor
@@ -244,6 +244,11 @@ def calculate_workload_scores(workload: Workload, region: CloudRegion) -> tuple[
                     (transfer_carbon_emission_rates, \
                         transfer_network_carbon_emission_rates, \
                         transfer_endpoint_carbon_emission_rates) = all_transfer_carbon_emission_rates
+
+                    if workload.use_new_optimization:
+                        calculate_total_carbon_emissions = calculate_total_carbon_emissions_linear
+                    else:
+                        calculate_total_carbon_emissions = calculate_total_carbon_emissions_naive
 
                     runtime = end - start
                     (compute_carbon_emissions, transfer_carbon_emission), timings = \


### PR DESCRIPTION
Current carbon optimization algorithm can take >10 seconds to run a single region over a 24-hour window, with hourly carbon intensity data. This will be too slow if we want to compare multiple regions in one run.

The main reason is that this algorithm sweep all three time variables in an optimized fashion, but still runs at $O(n^3)$ and thus can take >60k operations even when we skip times when the carbon intensity doesn't change.

We've since developed a new linear time algorithm, by pre-computing the integral and optimal points, thanks to my friend Zehan Chao. Current test shows that it now takes < 0.2s (99.9+% of the time is spent on integral and optimal points calculation) for a 24-hour window, aka at least >50x improvement, and it scales better when we look ahead for more than 24 hours ($O(n)$ vs $O(n^3)$ ).