### PR TITLE
Added electricity map iso mapping cache in database

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -9,7 +9,7 @@ import secrets
 import logging
 from werkzeug.exceptions import UnprocessableEntity, HTTPException
 
-from api.util import DocstringDefaultException, CustomJSONEncoder, simple_cache, carbon_data_cache
+from api.util import DocstringDefaultException, CustomJSONEncoder, simple_cache, carbon_data_cache, iso_cache
 
 
 class CustomApi(Api):
@@ -33,6 +33,7 @@ def create_app():
         'cls': CustomJSONEncoder
     }
     simple_cache.init_app(app)
+    iso_cache.init_app(app)
     carbon_data_cache.init_app(app)
     if __name__ != '__main__':
         # Source: https://trstringer.com/logging-flask-gunicorn-the-manageable-way/

--- a/api/external/electricitymap/export_emap_cached_ba_to_loc.py
+++ b/api/external/electricitymap/export_emap_cached_ba_to_loc.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import argparse
+import requests_cache
+from urllib.parse import urlparse, parse_qs
+
+
+BA_QUERY_URL = 'https://api-access.electricitymaps.com/free-tier/home-assistant'
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dir-path', '-d', type=str, required=True, help='Directory path of the cache')
+    parser.add_argument('--output', '-o', type=argparse.FileType('w'), required=True,
+                        help='Output file name')
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parse_args()
+    args.output.write('lat,lon,ba\n')
+    session = requests_cache.CachedSession(backend='filesystem', cache_name=args.dir_path)
+    for key in session.cache.responses:
+        response = session.cache.responses[key]
+        if response.url.startswith(BA_QUERY_URL) and response.ok:
+            params = parse_qs(urlparse(response.url).query)
+            lat = params['lat'][0]
+            lon = params['lon'][0]
+            ba = response.json()['countryCode']
+            args.output.write(f'{lat},{lon},{ba}\n')
+        else:
+            print('Ignored', key, response.url, response.status_code)
+
+if __name__ == '__main__':
+    main()

--- a/api/helpers/balancing_authority.py
+++ b/api/helpers/balancing_authority.py
@@ -55,7 +55,7 @@ def convert_watttime_ba_abbrev_to_c3lab_region(watttime_abbrev) -> str:
 def lookup_watttime_balancing_authority(latitude: float, longitude: float) -> dict[str, Any]:
     """
         Lookup the balancing authority from WattTime API, and returns the WattTime lookup result."""
-    current_app.logger.debug(f'lookup_watttime_balancing_authority({latitude}, {longitude})')
+    current_app.logger.info(f'lookup_watttime_balancing_authority({latitude}, {longitude})')
     watttime_response = get_watttime_ba_from_loc(latitude, longitude)
     watttime_json = watttime_response.json()
 
@@ -79,7 +79,7 @@ def lookup_watttime_balancing_authority(latitude: float, longitude: float) -> di
 
 def lookup_emap_balancing_authority_from_api(latitude: float, longitude: float) -> str:
     """Lookup the balancing authority from EMAP API, and returns the zone id (country code)."""
-    current_app.logger.debug(f'lookup_emap_balancing_authority({latitude}, {longitude})')
+    current_app.logger.info(f'lookup_emap_balancing_authority({latitude}, {longitude})')
     emap_response = get_emap_ba_from_loc(latitude, longitude)
     emap_json = emap_response.json()
 

--- a/database/tables/index.balancing-authority.sql
+++ b/database/tables/index.balancing-authority.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX index_balancing_authority
+    ON balancing_authority (latitude, longitude, provider, balancing_authority);

--- a/database/tables/table.balancing-authority.sql
+++ b/database/tables/table.balancing-authority.sql
@@ -1,0 +1,6 @@
+CREATE TABLE balancing_authority (
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL,
+    provider VARCHAR(32) NOT NULL,
+    balancing_authority VARCHAR(32) NOT NULL
+);

--- a/database/views/view.balancing-authority-loose-granularity.sql
+++ b/database/views/view.balancing-authority-loose-granularity.sql
@@ -1,0 +1,20 @@
+CREATE VIEW
+    balancing_authority_loose_granularity
+AS
+WITH cte AS (
+    SELECT
+        CAST(latitude AS NUMERIC(5, 1)) AS latitude,
+        CAST(longitude AS NUMERIC(5, 1)) AS longitude,
+        provider,
+        balancing_authority
+    FROM balancing_authority
+),
+row_number_cte AS (
+    SELECT latitude, longitude, provider, balancing_authority, COUNT(*) AS row_count,
+           ROW_NUMBER() OVER (PARTITION BY latitude, longitude, provider ORDER BY COUNT(*) DESC) AS rn
+    FROM cte
+    GROUP BY latitude, longitude, provider, balancing_authority
+)
+SELECT latitude, longitude, provider, balancing_authority
+    FROM row_number_cte
+    WHERE rn = 1;


### PR DESCRIPTION
To avoid unnecessary calls, we can round (lat, lon) coordinates to 0.1 precision and consider the loose match when exact match fails.